### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 simpleValidator
 ===============
 
-[![PyPI version](https://badge.fury.io/py/simpleValidator.png)](http://badge.fury.io/py/simpleValidator) [![Build Status](https://travis-ci.org/markleent/simpleValidator.png?branch=master)](https://travis-ci.org/markleent/simpleValidator) [![Coverage Status](https://coveralls.io/repos/markleent/simpleValidator/badge.png?branch=master)](https://coveralls.io/r/markleent/simpleValidator?branch=master) [![Downloads](https://pypip.in/d/simpleValidator/badge.png)](https://pypi.python.org/pypi/simpleValidator/) [![License](https://pypip.in/license/simpleValidator/badge.png)](https://pypi.python.org/pypi/simpleValidator/)
+[![PyPI version](https://badge.fury.io/py/simpleValidator.png)](http://badge.fury.io/py/simpleValidator) [![Build Status](https://travis-ci.org/markleent/simpleValidator.png?branch=master)](https://travis-ci.org/markleent/simpleValidator) [![Coverage Status](https://coveralls.io/repos/markleent/simpleValidator/badge.png?branch=master)](https://coveralls.io/r/markleent/simpleValidator?branch=master) [![Downloads](https://img.shields.io/pypi/dm/simpleValidator.svg)](https://pypi.python.org/pypi/simpleValidator/) [![License](https://img.shields.io/pypi/l/simpleValidator.svg)](https://pypi.python.org/pypi/simpleValidator/)
 
 
 A small, extensible python 2 (and 3 compatible !) library to deal with web validations !


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20simplevalidator))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `simplevalidator`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.